### PR TITLE
Enable lingering for user juneogo

### DIFF
--- a/preparation.sh
+++ b/preparation.sh
@@ -12,6 +12,8 @@ if ! id -u juneogo > /dev/null 2>&1; then
   usermod -aG sudo juneogo
 fi
 
+loginctl enable-linger juneogo
+
 # SSH Key Configuration
 read -p "Do you want to add an SSH key for user juneogo? (y/n) " add_ssh_key
 if [ "$add_ssh_key" = "y" ]; then


### PR DESCRIPTION
When we install the node using this [instruction](https://docs.juneo.com/intro/build/set-up-and-connect-a-node), the linux service starts at the user context. In this case, when the user is detached from the console, the service stops and will be started when the user logs in again. The node goes offline.

This PR enables lingering for the user `juneogo`. It helps to keep the node running after logging out.